### PR TITLE
Fix mods not being debuggable

### DIFF
--- a/StationieersMods/StationeersMods.Editor/Export.cs
+++ b/StationieersMods/StationeersMods.Editor/Export.cs
@@ -70,15 +70,27 @@ namespace StationeersMods.Editor
                 var asmDef = JsonUtility.FromJson<AsmDef>(json);
 
                 var modAsmPath = Path.Combine("Library", "ScriptAssemblies", $"{asmDef.name}.dll");
+                var modPdbPath = Path.Combine("Library", "ScriptAssemblies", $"{asmDef.name}.pdb");
 
                 if (!File.Exists(modAsmPath))
                 {
-                    LogUtility.LogError($"{asmDef.name} not found: {modAsmPath}");
+                    LogUtility.LogError($"{asmDef.name}.dll not found: {modAsmPath}");
+                    continue;
+                }
+
+                if (settings.IncludePdbs && !File.Exists(modPdbPath))
+                {
+                    LogUtility.LogError($"{asmDef.name}.pdb not found: {modPdbPath}");
                     continue;
                 }
 
                 LogUtility.LogDebug($" - {asmDef.name}");
                 File.Copy(modAsmPath, Path.Combine(tempModDirectory, $"{asmDef.name}.dll"));
+
+                if (settings.IncludePdbs)
+                {
+                    File.Copy(modPdbPath, Path.Combine(tempModDirectory, $"{asmDef.name}.pdb"));
+                }
             }
         }
 

--- a/StationieersMods/StationeersMods.Editor/ExportEditor.cs
+++ b/StationieersMods/StationeersMods.Editor/ExportEditor.cs
@@ -75,6 +75,11 @@ namespace StationeersMods.Editor
             }
         }
 
+        private void DrawPdbSelector(ExportSettings settings)
+        {
+            settings.IncludePdbs = EditorGUILayout.Toggle("Include PDBs:", settings.IncludePdbs);
+        }
+
         private void DrawBootSelector(ExportSettings settings)
         {
             var content = settings.ContentTypes;
@@ -183,6 +188,7 @@ namespace StationeersMods.Editor
         {
             DrawSection(() => {
                 DrawLogSelector();
+                DrawPdbSelector(settings);
                 DrawDirectorySelector(settings);
             });
         }

--- a/StationieersMods/StationeersMods.Editor/ExportSettingsEditor.cs
+++ b/StationieersMods/StationeersMods.Editor/ExportSettingsEditor.cs
@@ -22,6 +22,7 @@ namespace StationeersMods.Editor
         private SerializedProperty _description;
         private SerializedProperty _name;
         private SerializedProperty _outputDirectory;
+        private SerializedProperty _includePdbs;
         private SerializedProperty _version;
         private SerializedProperty _prefab;
         private SerializedProperty _scene;
@@ -39,6 +40,7 @@ namespace StationeersMods.Editor
             _description = serializedObject.FindProperty("_description");
             _version = serializedObject.FindProperty("_version");
             _outputDirectory = serializedObject.FindProperty("_outputDirectory");
+            _includePdbs = serializedObject.FindProperty("_includePdbs");
             _prefab = serializedObject.FindProperty("_startupPrefab");
             _scene = serializedObject.FindProperty("_startupScene");
             _class = serializedObject.FindProperty("_startupClass");
@@ -204,6 +206,11 @@ namespace StationeersMods.Editor
             LogUtility.logLevel = (LogLevel)EditorGUILayout.EnumPopup("Log Level:", LogUtility.logLevel);
         }
 
+        private void DrawPdbSelector()
+        {
+            _includePdbs.boolValue = EditorGUILayout.Toggle("Include PDBs:", _includePdbs.boolValue);
+        }
+
         private void DrawAssemblySelector()
         {
             DrawSection(() =>
@@ -226,6 +233,7 @@ namespace StationeersMods.Editor
         {
             DrawSection(() => {
                 DrawLogSelector();
+                DrawPdbSelector();
                 DrawDirectorySelector();
             });
         }

--- a/StationieersMods/StationeersMods.Shared/ExportSettings.cs
+++ b/StationieersMods/StationeersMods.Shared/ExportSettings.cs
@@ -32,6 +32,8 @@ namespace StationeersMods.Shared
 
         [SerializeField] private ContentType _contentTypes;
 
+        [SerializeField] private bool _includePdbs;
+
         [SerializeField] private BootType _bootType;
 
         [SerializeField] private GameObject _startupPrefab;
@@ -87,6 +89,8 @@ namespace StationeersMods.Shared
         public string OutputDirectory { get => _outputDirectory; set => _outputDirectory = value; }
 
         public ContentType ContentTypes { get => _contentTypes; set => _contentTypes =value;}
+
+        public bool IncludePdbs { get => _includePdbs; set => _includePdbs = value; }
 
         public BootType BootType { get => _bootType; set => _bootType =value;}
 

--- a/StationieersMods/StationeersMods/AssemblyMod.cs
+++ b/StationieersMods/StationeersMods/AssemblyMod.cs
@@ -189,7 +189,7 @@ namespace StationeersMods
 
                 try
                 {
-                    var assembly = Assembly.Load(File.ReadAllBytes(path));
+                    var assembly = Assembly.LoadFrom(path);
                     assembly.GetTypes();
                     assemblies.Add(assembly);
                 }


### PR DESCRIPTION
Optionally copy assembly PDBs along with export, and change assembly load to allow it to find the copied PDBs. This makes the unity plugin find the PDB and makes debugging work (assuming the game was set up to allow it).