### PR TITLE
Add development features

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,34 +116,6 @@ There are a number of settings for an Asmdef so let's take a look at some import
 - **Assembly References** : Will only appear if `Override References` is true. Use this to name the precompiled-assemblies that your assetmod depends on.
 - **Platforms** : Should always be exactly as shown for all assetmod Asmdefs.
 
-### Debugging
-
-To be able to attach to the game, you need to have an IDE installed with the Unity debugger extensions. For Visual Studio, this is the Visual Studio Tools for Unity (VSTU).
-
-To enable debugging, the first step is to set Stationeers to development mode. The easiest way to do this is to use the StationeersMods menu in Unity to enable development mode automatically. The steps to do it manually are as follows:
-- Edit `[game folder]/rocketstation_Data/boot.config` and add the line: `player-connection-debug=1`
-- Copy the following files from `C:\Program Files\Unity 2021.2.13f1\Editor\Data\PlaybackEngines\windowsstandalonesupport\Variations\win64_player_development_mono`:
-  - `WindowsPlayer.exe` (to `[game folder]/rocketstation.exe`)
-  - `UnityPlayer.dll` (to `[game folder]/UnityPlayer.dll`)
-  - `MonoBleedingEdge/EmbedRuntime/mono-2.0-bdwgc.dll` (to `[game folder]/MonoBleedingEdge/EmbedRuntime/mono-2.0-bdwgc.dll`)
-
-After the game has been set to development mode, you should be able to attach. However, you need symbols to be able to actually debug.
-
-To debug your own mod code when building **with** Unity:
-- Make sure "Include PDBs" is checked in the export settings.
-
-To debug your own mod code when building a standalone code mod **without** Unity:
-- Make sure you're building with debug information and `project properties -> Build -> Advanced... -> Debugging information` is set to "Portable". This is the only format supported by VSTU. 
-- Make sure the generated .pdb is copied along with the .dll to the exported mod folder.
-
-To debug code from the game:
-- Find `[game folder]/rocketstation_Data/Managed/Assembly-CSharp.dll`. This file contains (most of) the game's code.
-- Install dotPeek and load up `Assembly-CSharp.dll`. After it loads, right-click Assembly-CSharp in the Assembly Exporer and select "Generate Pdb...". Export anywhere.
-- After exporting, copy the exported .pdb file (either works) next to `Assembly-CSharp.dll` in the Stationeers directory.
-- When debugging, you should now be able to step through and see any Stationeers code.
-
-> *Note that this seems to work only with dotPeek since other tools (ILSpy, dnSpy, etc) do not export the .pdb in the correct (portable with external code) format.*
-
 ## Exported Assetmod Content
 
 Once you've exported your assetmod you should find the following content:

--- a/README.md
+++ b/README.md
@@ -136,13 +136,13 @@ To debug your own mod code when building a standalone code mod **without** Unity
 - Make sure you're building with debug information and `project properties -> Build -> Advanced... -> Debugging information` is set to "Portable". This is the only format supported by VSTU. 
 - Make sure the generated .pdb is copied along with the .dll to the exported mod folder.
 
-> *Note that this seems to work only with dotPeek since other tools (ILSpy, dnSpy, etc) do not export the .pdb in the correct (portable with external code) format.*
-
 To debug code from the game:
 - Find `[game folder]/rocketstation_Data/Managed/Assembly-CSharp.dll`. This file contains (most of) the game's code.
 - Install dotPeek and load up `Assembly-CSharp.dll`. After it loads, right-click Assembly-CSharp in the Assembly Exporer and select "Generate Pdb...". Export anywhere.
 - After exporting, copy the exported .pdb file (either works) next to `Assembly-CSharp.dll` in the Stationeers directory.
 - When debugging, you should now be able to step through and see any Stationeers code.
+
+> *Note that this seems to work only with dotPeek since other tools (ILSpy, dnSpy, etc) do not export the .pdb in the correct (portable with external code) format.*
 
 ## Exported Assetmod Content
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,34 @@ There are a number of settings for an Asmdef so let's take a look at some import
 - **Assembly References** : Will only appear if `Override References` is true. Use this to name the precompiled-assemblies that your assetmod depends on.
 - **Platforms** : Should always be exactly as shown for all assetmod Asmdefs.
 
+### Debugging
+
+To be able to attach to the game, you need to have an IDE installed with the Unity debugger extensions. For Visual Studio, this is the Visual Studio Tools for Unity (VSTU).
+
+To enable debugging, the first step is to set Stationeers to development mode. The easiest way to do this is to use the StationeersMods menu in Unity to enable development mode automatically. The steps to do it manually are as follows:
+- Edit `[game folder]/rocketstation_Data/boot.config` and add the line: `player-connection-debug=1`
+- Copy the following files from `C:\Program Files\Unity 2021.2.13f1\Editor\Data\PlaybackEngines\windowsstandalonesupport\Variations\win64_player_development_mono`:
+  - `WindowsPlayer.exe` (to `[game folder]/rocketstation.exe`)
+  - `UnityPlayer.dll` (to `[game folder]/UnityPlayer.dll`)
+  - `MonoBleedingEdge/EmbedRuntime/mono-2.0-bdwgc.dll` (to `[game folder]/MonoBleedingEdge/EmbedRuntime/mono-2.0-bdwgc.dll`)
+
+After the game has been set to development mode, you should be able to attach. However, you need symbols to be able to actually debug.
+
+To debug your own mod code when building **with** Unity:
+- Make sure "Include PDBs" is checked in the export settings.
+
+To debug your own mod code when building a standalone code mod **without** Unity:
+- Make sure you're building with debug information and `project properties -> Build -> Advanced... -> Debugging information` is set to "Portable". This is the only format supported by VSTU. 
+- Make sure the generated .pdb is copied along with the .dll to the exported mod folder.
+
+> *Note that this seems to work only with dotPeek since other tools (ILSpy, dnSpy, etc) do not export the .pdb in the correct (portable with external code) format.*
+
+To debug code from the game:
+- Find `[game folder]/rocketstation_Data/Managed/Assembly-CSharp.dll`. This file contains (most of) the game's code.
+- Install dotPeek and load up `Assembly-CSharp.dll`. After it loads, right-click Assembly-CSharp in the Assembly Exporer and select "Generate Pdb...". Export anywhere.
+- After exporting, copy the exported .pdb file (either works) next to `Assembly-CSharp.dll` in the Stationeers directory.
+- When debugging, you should now be able to step through and see any Stationeers code.
+
 ## Exported Assetmod Content
 
 Once you've exported your assetmod you should find the following content:

--- a/StationieersMods/StationeersMods.Editor/DevelopmentEditor.cs
+++ b/StationieersMods/StationeersMods.Editor/DevelopmentEditor.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Assets.Scripts.Objects.Pipes;
+using StationeersMods.Shared;
+using UnityEditor;
+using UnityEngine;
+
+namespace StationeersMods.Editor
+{
+    class DevelopmentEditor
+    {
+        public DevelopmentPatcher Patcher { get; } = new DevelopmentPatcher();
+
+        public bool Draw(ExportSettings settings)
+        {
+            EditorGUILayout.HelpBox("Various options to assist in mod development. Enabling development mode allows you to attach to the game and debug your code.", MessageType.Info, true);
+
+            if (!settings.IncludePdbs)
+            {
+                EditorGUILayout.HelpBox("Debug information needs to be exported or it will not be possible to debug your code. Enable Export Settings > Export > Include PDBs.", MessageType.Error, true);
+            }
+
+            // Stationeers path
+            GUILayout.BeginHorizontal();
+
+            settings.StationeersDirectory = EditorGUILayout.TextField("Stationeers directory:", settings.StationeersDirectory);
+
+            if (GUILayout.Button("...", GUILayout.Width(30)))
+            {
+                var selectedDirectory =
+                    EditorUtility.SaveFolderPanel("Choose Stationeers directory", settings.StationeersDirectory, "");
+                if (!string.IsNullOrEmpty(selectedDirectory))
+                    settings.StationeersDirectory = selectedDirectory;
+            }
+
+            GUILayout.EndHorizontal();
+
+            settings.StationeersArguments = EditorGUILayout.TextField("Stationeers arguments:", settings.StationeersArguments);
+
+            GUILayout.Space(5);
+
+            // Development mode
+            GUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("Stationeers is currently in mode: " + (!Patcher.DevelopmentModeEnabled.HasValue ? "UNKNOWN" : (Patcher.DevelopmentModeEnabled.Value ? "DEVELOPMENT" : "RELEASE")));
+            if (GUILayout.Button("Check", GUILayout.Width(200)))
+            {
+                Patcher.CheckDevelopmentMode(settings);
+            }
+            GUILayout.EndHorizontal();
+
+            GUILayout.Space(10);
+            GUILayout.BeginHorizontal();
+            GUILayout.Space(50);
+
+            if (GUILayout.Button("Enable development mode"))
+            {
+                Patcher.SetDevelopmentMode(settings, true);
+            }
+
+            GUILayout.Space(5);
+
+            if (GUILayout.Button("Disable development mode"))
+            {
+                Patcher.SetDevelopmentMode(settings, false);
+            }
+
+            GUILayout.Space(50);
+            GUILayout.EndHorizontal();
+
+            return true;
+        }
+    }
+}

--- a/StationieersMods/StationeersMods.Editor/DevelopmentEditor.cs
+++ b/StationieersMods/StationeersMods.Editor/DevelopmentEditor.cs
@@ -18,11 +18,11 @@ namespace StationeersMods.Editor
 
         public bool Draw(ExportSettings settings)
         {
-            EditorGUILayout.HelpBox("Various options to assist in mod development. Enabling development mode allows you to attach to the game and debug your code.", MessageType.Info, true);
+            EditorGUILayout.HelpBox("Various options to assist in mod development. Enabling development mode allows you to attach to the game and debug your code. See https://github.com/jixxed/StationeersMods/tree/main/doc/DEBUGGING.md for a guide.", MessageType.Info, true);
 
             if (!settings.IncludePdbs)
             {
-                EditorGUILayout.HelpBox("Debug information needs to be exported or it will not be possible to debug your code. Enable Export Settings > Export > Include PDBs.", MessageType.Error, true);
+                EditorGUILayout.HelpBox("Debug information needs to be exported or it will not be possible to debug your code. Enable Export > Include PDBs.", MessageType.Warning, true);
             }
 
             // Stationeers path

--- a/StationieersMods/StationeersMods.Editor/DevelopmentPatcher.cs
+++ b/StationieersMods/StationeersMods.Editor/DevelopmentPatcher.cs
@@ -1,0 +1,110 @@
+﻿using StationeersMods.Shared;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEditor;
+
+namespace StationeersMods.Editor
+{
+    public class DevelopmentPatcher
+    {
+        public bool? DevelopmentModeEnabled { get; private set; }
+
+        public string PathToBootConfig(ExportSettings settings) => Path.Combine(settings.StationeersDirectory, "rocketstation_Data", "boot.config");
+        public string PathToPlayerDirectory => Path.Combine(EditorApplication.applicationContentsPath, "PlaybackEngines/windowsstandalonesupport/Variations");
+        public string PathToStationeersExecutable(ExportSettings settings) => Path.Combine(settings.StationeersDirectory, "rocketstation.exe");
+        public string PathToStationeersPlayer(ExportSettings settings) => Path.Combine(settings.StationeersDirectory, "UnityPlayer.dll");
+        public string PathToStationeersMono(ExportSettings settings) => Path.Combine(settings.StationeersDirectory, "MonoBleedingEdge/EmbedRuntime/mono-2.0-bdwgc.dll");
+
+        public string DevelopmentExecutablePath => Path.Combine(PathToPlayerDirectory, "win64_player_development_mono/WindowsPlayer.exe");
+        public string DevelopmentPlayerPath => Path.Combine(PathToPlayerDirectory, "win64_player_development_mono/UnityPlayer.dll");
+        public string DevelopmentMonoPath => Path.Combine(PathToPlayerDirectory, "win64_player_development_mono/MonoBleedingEdge/EmbedRuntime/mono-2.0-bdwgc.dll");
+
+        public string ReleaseExecutablePath => Path.Combine(PathToPlayerDirectory, "win64_player_nondevelopment_mono/WindowsPlayer.exe");
+        public string ReleasePlayerPath => Path.Combine(PathToPlayerDirectory, "win64_player_nondevelopment_mono/UnityPlayer.dll");
+        public string ReleaseMonoPath => Path.Combine(PathToPlayerDirectory, "win64_player_nondevelopment_mono/MonoBleedingEdge/EmbedRuntime/mono-2.0-bdwgc.dll");
+
+        private bool ValidateDirectory(ExportSettings settings)
+        {
+            if (string.IsNullOrEmpty(settings.StationeersDirectory))
+            {
+                EditorUtility.DisplayDialog("Error", "The Stationeers directory is not set", "OK");
+                return false;
+            }
+
+            if (!Directory.Exists(settings.StationeersDirectory))
+            {
+                EditorUtility.DisplayDialog("Error", "The Stationeers directory is not valid", "OK");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool CheckIsIdentical(string fileA, string fileB)
+        {
+            var fileInfoA = new FileInfo(fileA);
+            var fileInfoB = new FileInfo(fileB);
+
+            // Check the filesize, and then check the timestamp - if they match, we're good
+            return fileInfoA.LastWriteTime == fileInfoB.LastWriteTime && fileInfoA.Length == fileInfoB.Length;
+        }
+
+        public void CheckDevelopmentMode(ExportSettings settings)
+        {
+            if (!ValidateDirectory(settings))
+            {
+                DevelopmentModeEnabled = null;
+                return;
+            }
+
+            // Check the player connection option is enabled
+            var configLines = File.ReadAllLines(PathToBootConfig(settings));
+            if (!configLines.Contains("player-connection-debug=1"))
+            {
+                // Config option is not set
+                DevelopmentModeEnabled = false;
+                return;
+            }
+
+            // Check if we're currently using the development executable, development player dll, and development mono
+            if (!CheckIsIdentical(PathToStationeersExecutable(settings), DevelopmentExecutablePath) ||
+                !CheckIsIdentical(PathToStationeersPlayer(settings), DevelopmentPlayerPath) ||
+                !CheckIsIdentical(PathToStationeersMono(settings), DevelopmentMonoPath))
+            {
+                DevelopmentModeEnabled = false;
+                return;
+            }
+
+            // Both files are good, so debugging should work
+            DevelopmentModeEnabled = true;
+        }
+
+        public void SetDevelopmentMode(ExportSettings settings, bool enabled)
+        {
+            if (!ValidateDirectory(settings))
+            {
+                EditorUtility.DisplayDialog("Error", "Development mode cannot be toggled: the Stationeers directory is not valid", "OK");
+                return;
+            }
+
+            // Change player connection line
+            var configLines = File.ReadAllLines(PathToBootConfig(settings));
+            var newConfigLines = configLines.Where(line => !line.Contains("player-connection-debug")).ToList();
+            newConfigLines.Add($"player-connection-debug={(enabled ? 1 : 0)}");
+            File.WriteAllLines(PathToBootConfig(settings), newConfigLines);
+
+            // Change files
+            // Note that the nondevelopment executable isn't 100% identical to the stationeers executable since it has no icon
+            File.Copy(enabled ? DevelopmentExecutablePath : ReleaseExecutablePath, PathToStationeersExecutable(settings), true);
+            File.Copy(enabled ? DevelopmentMonoPath : ReleaseMonoPath, PathToStationeersMono(settings), true);
+            File.Copy(enabled ? DevelopmentPlayerPath : ReleasePlayerPath, PathToStationeersPlayer(settings), true);
+
+            // Verify change
+            CheckDevelopmentMode(settings);
+        }
+    }
+}

--- a/StationieersMods/StationeersMods.Editor/Export.cs
+++ b/StationieersMods/StationeersMods.Editor/Export.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using StationeersMods.Shared;
 using UnityEditor;
 using UnityEngine;
+using Debug = UnityEngine.Debug;
 
 namespace StationeersMods.Editor
 {
@@ -208,6 +210,19 @@ namespace StationeersMods.Editor
             var exporter = new Export(settings);
             EditorUtility.SetDirty(settings);
             exporter.Run();
+        }
+
+        public static void RunGame(ExportSettings settings)
+        {
+            var patcher = new DevelopmentPatcher();
+
+            string pathToStationeers = patcher.PathToStationeersExecutable(settings);
+            if (!File.Exists(pathToStationeers))
+            {
+                throw new FileNotFoundException($"Game executable not found at \"{pathToStationeers}\". Make sure the Stationeers directory is configured correctly under export settings.");
+            }
+
+            Process.Start(pathToStationeers, settings.StationeersArguments ?? "");
         }
     }
 }

--- a/StationieersMods/StationeersMods.Editor/ExportEditor.cs
+++ b/StationieersMods/StationeersMods.Editor/ExportEditor.cs
@@ -13,21 +13,6 @@ namespace StationeersMods.Editor
 
     class ExportEditor
     {
-        private string GetShortString(string str)
-        {
-            if (str == null)
-            {
-                return null;
-            }
-
-            var maxWidth = (int)EditorGUIUtility.currentViewWidth - 252;
-            var cutoffIndex = Mathf.Max(0, str.Length - 7 - maxWidth / 7);
-            var shortString = str.Substring(cutoffIndex);
-            if (cutoffIndex > 0)
-                shortString = "..." + shortString;
-            return shortString;
-        }
-
         private void DrawSection(Action thunk)
         {
             EditorGUILayout.BeginVertical(EditorStyles.helpBox, GUILayout.ExpandWidth(true));
@@ -162,7 +147,7 @@ namespace StationeersMods.Editor
         {
             GUILayout.BeginHorizontal();
 
-            EditorGUILayout.TextField("Output Directory*:", GetShortString(settings.OutputDirectory));
+            EditorGUILayout.TextField("Output Directory*:", ExporterEditorWindow.GetShortString(settings.OutputDirectory));
 
             if (GUILayout.Button("...", GUILayout.Width(30)))
             {

--- a/StationieersMods/StationeersMods.Editor/ExportSettingsEditor.cs
+++ b/StationieersMods/StationeersMods.Editor/ExportSettingsEditor.cs
@@ -1,6 +1,7 @@
 ﻿using StationeersMods.Shared;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -22,6 +23,8 @@ namespace StationeersMods.Editor
         private SerializedProperty _description;
         private SerializedProperty _name;
         private SerializedProperty _outputDirectory;
+        private SerializedProperty _stationeersDirectory;
+        private SerializedProperty _stationeersArguments;
         private SerializedProperty _includePdbs;
         private SerializedProperty _version;
         private SerializedProperty _prefab;
@@ -40,6 +43,8 @@ namespace StationeersMods.Editor
             _description = serializedObject.FindProperty("_description");
             _version = serializedObject.FindProperty("_version");
             _outputDirectory = serializedObject.FindProperty("_outputDirectory");
+            _stationeersDirectory = serializedObject.FindProperty("_stationeersDirectory");
+            _stationeersArguments = serializedObject.FindProperty("_stationeersArguments");
             _includePdbs = serializedObject.FindProperty("_includePdbs");
             _prefab = serializedObject.FindProperty("_startupPrefab");
             _scene = serializedObject.FindProperty("_startupScene");
@@ -177,23 +182,47 @@ namespace StationeersMods.Editor
                 DrawStartupSelector(selectedBoot);
             });
         }
-        private void DrawDirectorySelector()
+
+        private void DrawDirectorySelector(string label, SerializedProperty path)
         {
             GUILayout.BeginHorizontal();
 
-            EditorGUILayout.TextField("Output Directory*:", GetShortString(_outputDirectory.stringValue));
+            path.stringValue = EditorGUILayout.TextField(label, path.stringValue);
 
             if (GUILayout.Button("...", GUILayout.Width(30)))
             {
                 var selectedDirectory =
-                    EditorUtility.SaveFolderPanel("Choose output directory", _outputDirectory.stringValue, "");
+                    EditorUtility.SaveFolderPanel("Choose directory", path.stringValue, "");
                 if (!string.IsNullOrEmpty(selectedDirectory))
-                    _outputDirectory.stringValue = selectedDirectory;
+                    path.stringValue = selectedDirectory;
 
                 Repaint();
             }
 
             GUILayout.EndHorizontal();
+        }
+
+        private void DrawStationeersDirectorySelector()
+        {
+            DrawDirectorySelector("Stationeers Directory:", _stationeersDirectory);
+        }
+
+        private void DrawStationeersArgumentSelector()
+        {
+            _stationeersArguments.stringValue = EditorGUILayout.TextField("Stationeers arguments:", _stationeersArguments.stringValue);
+        }
+
+        private void DrawDevelopmentOptions()
+        {
+            DrawSection(() => {
+                DrawStationeersDirectorySelector();
+                DrawStationeersArgumentSelector();
+            });
+        }
+
+        private void DrawOutputDirectorySelector()
+        {
+            DrawDirectorySelector("Output Directory*:", _outputDirectory);
 
             if (_outputDirectory.stringValue == "")
             {
@@ -234,7 +263,7 @@ namespace StationeersMods.Editor
             DrawSection(() => {
                 DrawLogSelector();
                 DrawPdbSelector();
-                DrawDirectorySelector();
+                DrawOutputDirectorySelector();
             });
         }
 
@@ -244,6 +273,7 @@ namespace StationeersMods.Editor
             DrawContentSection();
             DrawExportOptions();
             DrawAssemblySelector();
+            DrawDevelopmentOptions();
         }
 
         public override void OnInspectorGUI()
@@ -275,16 +305,6 @@ namespace StationeersMods.Editor
 
             serializedObject.ApplyModifiedProperties();
             return valid;
-        }
-
-        private string GetShortString(string str)
-        {
-            var maxWidth = (int) EditorGUIUtility.currentViewWidth - 252;
-            var cutoffIndex = Mathf.Max(0, str.Length - 7 - maxWidth / 7);
-            var shortString = str.Substring(cutoffIndex);
-            if (cutoffIndex > 0)
-                shortString = "..." + shortString;
-            return shortString;
         }
     }
 }

--- a/StationieersMods/StationeersMods.Editor/ExporterEditorWindow.cs
+++ b/StationieersMods/StationeersMods.Editor/ExporterEditorWindow.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.IO;
 using System.Collections.Generic;
 using System;
+using System.Diagnostics;
 
 namespace StationeersMods.Editor
 {
@@ -21,9 +22,24 @@ namespace StationeersMods.Editor
         ExportEditor exportEditor;
         AssemblyEditor assemblyEditor;
         ArtifactEditor artifactEditor;
+        DevelopmentEditor developmentEditor;
 
+        public static string GetShortString(string str)
+        {
+            if (str == null)
+            {
+                return null;
+            }
 
-        [MenuItem("StationeersMods/Export Mod")]
+            var maxWidth = (int)EditorGUIUtility.currentViewWidth - 252;
+            var cutoffIndex = Mathf.Max(0, str.Length - 7 - maxWidth / 7);
+            var shortString = str.Substring(cutoffIndex);
+            if (cutoffIndex > 0)
+                shortString = "..." + shortString;
+            return shortString;
+        }
+
+        [MenuItem("StationeersMods/Export Settings")]
         public static void ShowWindow()
         {
             var window = GetWindow<ExporterEditorWindow>();
@@ -33,6 +49,19 @@ namespace StationeersMods.Editor
             window.Focus();
         }
 
+        [MenuItem("StationeersMods/Export Mod", false, 20)]
+        public static void ExportModMenuItem()
+        {
+            ExportMod();
+        }
+
+        [MenuItem("StationeersMods/Export && Run Mod", false, 20)]
+        public static void ExportAndRunModMenuItem()
+        {
+            ExportMod();
+            RunGame();
+        }
+
         private void OnEnable()
         {
             exportSettings = new EditorScriptableSingleton<ExportSettings>();
@@ -40,6 +69,7 @@ namespace StationeersMods.Editor
             assemblyEditor = new AssemblyEditor();
             artifactEditor = new ArtifactEditor();
             exportEditor = new ExportEditor();
+            developmentEditor = new DevelopmentEditor();
         }
 
         private void OnDisable()
@@ -51,12 +81,27 @@ namespace StationeersMods.Editor
         {
             if (exportEditor.Draw(settings))
             {
-                var buttonPressed = GUILayout.Button("Save & Export", GUILayout.Height(30));
+                GUILayout.Space(10);
+                GUILayout.BeginHorizontal();
+                GUILayout.Space(50);
+
+                if (GUILayout.Button("Save & Export", GUILayout.Height(30)))
+                {
+                    Export.ExportMod(settings);
+                }
+
+                GUILayout.Space(5);
+
+                if (GUILayout.Button("Save & Export & Run", GUILayout.Height(30)))
+                {
+                    Export.ExportMod(settings);
+                    Export.RunGame(settings);
+                }
+
+                GUILayout.Space(50);
+                GUILayout.EndHorizontal();
 
                 GUILayout.FlexibleSpace();
-
-                if (buttonPressed)
-                    Export.ExportMod(settings);
             }
         }
 
@@ -66,7 +111,7 @@ namespace StationeersMods.Editor
 
             var settings = exportSettings.instance;
 
-            var tabs = new string[] { "Export", "Assemblies", "Copy Artifacts" };
+            var tabs = new string[] { "Export", "Assemblies", "Copy Artifacts", "Development" };
 
             selectedTab = GUILayout.Toolbar(selectedTab, tabs);
 
@@ -81,6 +126,9 @@ namespace StationeersMods.Editor
                 case "Copy Artifacts":
                     settings.Artifacts = artifactEditor.Draw(settings);
                     break;
+                case "Development":
+                    developmentEditor.Draw(settings);
+                    break;
             }
         }
 
@@ -88,6 +136,12 @@ namespace StationeersMods.Editor
         {
             var singleton = new EditorScriptableSingleton<ExportSettings>();
             Export.ExportMod(singleton.instance);
+        }
+
+        public static void RunGame()
+        {
+            var singleton = new EditorScriptableSingleton<ExportSettings>();
+            Export.RunGame(singleton.instance);
         }
     }
 }

--- a/StationieersMods/StationeersMods.Editor/StationeersMods.Editor.csproj
+++ b/StationieersMods/StationeersMods.Editor/StationeersMods.Editor.csproj
@@ -60,6 +60,8 @@
     <Compile Include="AssetUtility.cs" />
     <Compile Include="AssemblyEditor.cs" />
     <Compile Include="ArtifactEditor.cs" />
+    <Compile Include="DevelopmentEditor.cs" />
+    <Compile Include="DevelopmentPatcher.cs" />
     <Compile Include="SelectionEditor.cs" />
     <Compile Include="ExportEditor.cs" />
     <Compile Include="ExtraAssetsWindow.cs" />

--- a/StationieersMods/StationeersMods.Shared/ExportSettings.cs
+++ b/StationieersMods/StationeersMods.Shared/ExportSettings.cs
@@ -24,6 +24,10 @@ namespace StationeersMods.Shared
 
         [SerializeField] private string _outputDirectory;
 
+        [SerializeField] private string _stationeersDirectory;
+
+        [SerializeField] private string _stationeersArguments;
+
         [SerializeField] private string _version;
 
         [SerializeField] private string[] _assemblies = new string[] { };
@@ -87,6 +91,10 @@ namespace StationeersMods.Shared
         }
 
         public string OutputDirectory { get => _outputDirectory; set => _outputDirectory = value; }
+
+        public string StationeersDirectory { get => _stationeersDirectory; set => _stationeersDirectory = value; }
+
+        public string StationeersArguments { get => _stationeersArguments; set => _stationeersArguments = value; }
 
         public ContentType ContentTypes { get => _contentTypes; set => _contentTypes =value;}
 

--- a/doc/DEBUGGING.md
+++ b/doc/DEBUGGING.md
@@ -22,6 +22,6 @@ To debug code from the game:
 - Find `[game folder]/rocketstation_Data/Managed/Assembly-CSharp.dll`. This file contains (most of) the game's code.
 - Install dotPeek and load up `Assembly-CSharp.dll`. After it loads, right-click Assembly-CSharp in the Assembly Exporer and select "Generate Pdb...". Export anywhere. It may take a while to finish.
 - After exporting, copy the exported .pdb file (either works) next to `Assembly-CSharp.dll` in the Stationeers directory.
-- When debugging, you should now be able to step through and see any Stationeers code.
+- When debugging, you should now be able to step through and see any Stationeers code. See https://docs.unity3d.com/Manual/ManagedCodeDebugging.html for additional information.
 
 > *Note that this seems to work only with dotPeek since other tools (ILSpy, dnSpy, etc) do not export the .pdb in the correct (portable with external code) format.*

--- a/doc/DEBUGGING.md
+++ b/doc/DEBUGGING.md
@@ -1,0 +1,27 @@
+# Debugging
+
+To be able to attach to the game, you need to have an IDE installed with the Unity debugger extensions. For Visual Studio, this is the Visual Studio Tools for Unity (VSTU).
+
+The first step is to set Stationeers to development mode. The easiest way to do this is to use the StationeersMods menu in Unity to enable development mode automatically. The steps to do it manually are as follows:
+- Edit `[game folder]/rocketstation_Data/boot.config` and add the line: `player-connection-debug=1`
+- Copy the following files from `C:\Program Files\Unity 2021.2.13f1\Editor\Data\PlaybackEngines\windowsstandalonesupport\Variations\win64_player_development_mono`:
+  - `WindowsPlayer.exe` (to `[game folder]/rocketstation.exe`)
+  - `UnityPlayer.dll` (to `[game folder]/UnityPlayer.dll`)
+  - `MonoBleedingEdge/EmbedRuntime/mono-2.0-bdwgc.dll` (to `[game folder]/MonoBleedingEdge/EmbedRuntime/mono-2.0-bdwgc.dll`)
+
+After the game has been set to development mode, you should be able to attach. However, you need symbols to be able to actually debug.
+
+To debug your own mod code when building **with** Unity:
+- Make sure "Include PDBs" is checked in the export settings.
+
+To debug your own mod code when building a standalone code mod **without** Unity:
+- Make sure you're building with debug information and `project properties -> Build -> Advanced... -> Debugging information` is set to "Portable". This is the only format supported by VSTU. 
+- Make sure the generated .pdb is copied along with the .dll to the exported mod folder.
+
+To debug code from the game:
+- Find `[game folder]/rocketstation_Data/Managed/Assembly-CSharp.dll`. This file contains (most of) the game's code.
+- Install dotPeek and load up `Assembly-CSharp.dll`. After it loads, right-click Assembly-CSharp in the Assembly Exporer and select "Generate Pdb...". Export anywhere.
+- After exporting, copy the exported .pdb file (either works) next to `Assembly-CSharp.dll` in the Stationeers directory.
+- When debugging, you should now be able to step through and see any Stationeers code.
+
+> *Note that this seems to work only with dotPeek since other tools (ILSpy, dnSpy, etc) do not export the .pdb in the correct (portable with external code) format.*

--- a/doc/DEBUGGING.md
+++ b/doc/DEBUGGING.md
@@ -2,9 +2,9 @@
 
 To be able to attach to the game, you need to have an IDE installed with the Unity debugger extensions. For Visual Studio, this is the Visual Studio Tools for Unity (VSTU).
 
-The first step is to set Stationeers to development mode. The easiest way to do this is to use the StationeersMods menu in Unity to enable development mode automatically. The steps to do it manually are as follows:
+The first step is to set Stationeers to development mode. The automatic way to do this is to use the StationeersMods menu in Unity, navigate to the `Development` tab, and click `Enable development mode`. The steps to do it manually are as follows:
 - Edit `[game folder]/rocketstation_Data/boot.config` and add the line: `player-connection-debug=1`
-- Copy the following files from `C:\Program Files\Unity 2021.2.13f1\Editor\Data\PlaybackEngines\windowsstandalonesupport\Variations\win64_player_development_mono`:
+- Copy the following files from `[Unity installation folder]\Editor\Data\PlaybackEngines\windowsstandalonesupport\Variations\win64_player_development_mono`:
   - `WindowsPlayer.exe` (to `[game folder]/rocketstation.exe`)
   - `UnityPlayer.dll` (to `[game folder]/UnityPlayer.dll`)
   - `MonoBleedingEdge/EmbedRuntime/mono-2.0-bdwgc.dll` (to `[game folder]/MonoBleedingEdge/EmbedRuntime/mono-2.0-bdwgc.dll`)
@@ -20,7 +20,7 @@ To debug your own mod code when building a standalone code mod **without** Unity
 
 To debug code from the game:
 - Find `[game folder]/rocketstation_Data/Managed/Assembly-CSharp.dll`. This file contains (most of) the game's code.
-- Install dotPeek and load up `Assembly-CSharp.dll`. After it loads, right-click Assembly-CSharp in the Assembly Exporer and select "Generate Pdb...". Export anywhere.
+- Install dotPeek and load up `Assembly-CSharp.dll`. After it loads, right-click Assembly-CSharp in the Assembly Exporer and select "Generate Pdb...". Export anywhere. It may take a while to finish.
 - After exporting, copy the exported .pdb file (either works) next to `Assembly-CSharp.dll` in the Stationeers directory.
 - When debugging, you should now be able to step through and see any Stationeers code.
 


### PR DESCRIPTION
- A new menu in the export settings screen where you can enable/disable development mode. Enabling this lets you attach to the game with the Unity debugger and allows you to debug your code.
- A fields to enter your game folder + arguments, which allows you to do a save & export & run in one click, which saves a lot of time.
- Added an option in the "StationeersMods" menu in Unity to directly use the export and/or run functions without having to go through the settings screen.

Also removed GetShortString() from the export directory text field. Previously it would not allow you to edit or copy from the field directly which kept throwing me off.