### PR TITLE
Improve performance of Export Settings window.

### DIFF
--- a/StationeersMods/StationeersMods.Editor/AssemblyEditor.cs
+++ b/StationeersMods/StationeersMods.Editor/AssemblyEditor.cs
@@ -22,7 +22,7 @@ namespace StationeersMods.Editor
 
         public override List<string> GetCandidates(ExportSettings settings)
         {
-            if (_candidatesCache == null || _candidatesCache.Count == 0 )
+            if (_candidatesCache == null)
                 _candidatesCache = AssetUtility.GetAssets("t:AssemblyDefinitionAsset").ToList(); 
             return _candidatesCache;
         }
@@ -34,7 +34,7 @@ namespace StationeersMods.Editor
 
         public void ClearCandidates()
         {
-            _candidatesCache.Clear();
+            _candidatesCache = null;
         }
     }
 }

--- a/StationeersMods/StationeersMods.Editor/AssemblyEditor.cs
+++ b/StationeersMods/StationeersMods.Editor/AssemblyEditor.cs
@@ -10,6 +10,11 @@ namespace StationeersMods.Editor
 {
     internal class AssemblyEditor : SelectionEditor
     {
+        /// <summary>
+        /// Cached list of candidate Assembly Definitions found
+        /// </summary>
+        List <string> _candidatesCache = new List<string>();
+        
         public override void DrawHelpBox()
         {
             EditorGUILayout.HelpBox("Add asmdefs from your project to be exported into your mod.", MessageType.Info, true);
@@ -17,12 +22,19 @@ namespace StationeersMods.Editor
 
         public override List<string> GetCandidates(ExportSettings settings)
         {
-            return AssetUtility.GetAssets("t:AssemblyDefinitionAsset").ToList();
+            if (_candidatesCache == null || _candidatesCache.Count == 0 )
+                _candidatesCache = AssetUtility.GetAssets("t:AssemblyDefinitionAsset").ToList(); 
+            return _candidatesCache;
         }
 
         public override List<string> GetSelections(ExportSettings settings)
         {
             return settings.Assemblies.ToList();
+        }
+
+        public void ClearCandidates()
+        {
+            _candidatesCache.Clear();
         }
     }
 }

--- a/StationeersMods/StationeersMods.Editor/ExporterEditorWindow.cs
+++ b/StationeersMods/StationeersMods.Editor/ExporterEditorWindow.cs
@@ -72,6 +72,14 @@ namespace StationeersMods.Editor
             exportEditor = new ExportEditor();
         }
 
+        /// <summary>
+        /// Used to force refreshing the cached list of assemblies
+        /// </summary>
+        private void OnProjectChange()
+        {
+            assemblyEditor.ClearCandidates();
+        }
+        
         private void OnDisable()
         {
             DestroyImmediate(exportSettingsEditor);


### PR DESCRIPTION
Moved AssemblyDefinition list to a cache and implemented OnProjectChange to refresh it.

Based on @tsholmes comment that the poor performance is because the editor is trying to find the list of assembly definitions on every inspector Draw call.